### PR TITLE
Fix strict warning on stream_select()

### DIFF
--- a/SmartIRC.php
+++ b/SmartIRC.php
@@ -1661,9 +1661,10 @@ class Net_SmartIRC extends Net_SmartIRC_messagehandler
 
         // check the socket to see if data is waiting for us
         // this will trigger a warning when a signal is received
-        $result = stream_select($r = array($this->_socket), $w = null, $e = null,
-            0, $selecttimeout
-        );
+        $r = array($this->_socket);
+        $w = null;
+        $e = null;
+        $result = stream_select($r, $w, $e, 0, $selecttimeout);
 
         $rawdata = null;
 


### PR DESCRIPTION
Only variables should be passed by reference in Net_SmartIRC->listenOnce() (line 1659 of ./Net/SmartIRC.php)

Commented here: http://pear.php.net/bugs/bug.php?id=18774#1425774726

Tried creating a new bug at:
http://pear.php.net/bugs/report.php?package=Net_SmartIRC

But it says:
`Net_SmartIRC has an external bug system that can be reached at http://pear.php.net/package/Net_SmartIRC/bugs`