### PR TITLE
fix variable refs warning

### DIFF
--- a/Net/SmartIRC.php
+++ b/Net/SmartIRC.php
@@ -2685,7 +2685,8 @@ class Net_SmartIRC extends Net_SmartIRC_messagehandler
 
     protected function &throwError($message)
     {
-        return new Net_SmartIRC_Error($message);
+        $var = new Net_SmartIRC_Error($message);
+        return $var;
     }
 }
 


### PR DESCRIPTION
attempt to upstream this patch:
https://github.com/pld-linux/php-pear-Net_SmartIRC/commits/auto/th/php-pear-Net_SmartIRC-1.1.10-1/php-pear-Net_SmartIRC-refs.patch