### PR TITLE
Add global statement for $SMARTIRC_nreplycodes

### DIFF
--- a/Net/SmartIRC/defines.php
+++ b/Net/SmartIRC/defines.php
@@ -87,6 +87,7 @@ define('SMARTIRC_TYPE_CTCP_REPLY',     536870912);
 //define('SMARTIRC_TYPE_DCC',            536870912);
 define('SMARTIRC_TYPE_ALL',            1073741823);
 
+global $SMARTIRC_nreplycodes;
 // see https://www.alien.net.au/irc/irc2numerics.html
 $SMARTIRC_nreplycodes = array(
 '001' =>              'RPL_WELCOME',


### PR DESCRIPTION
The variable wasn't defined to be global in SmartIRC/defines.php but in
SmartIRC.php (__construct) it is expected to be in the global scope.

The lack of being global means that a lot of functions don't work, which caused a bot I'm working on to fail to join any channels on FreeNode. The failure to join was presumably because it didn't know what to do with some of the incoming messages from the server so didn't reply causing the server to restrict the bot's ability to join channels.

Signed-off-by: Daniel Llewellyn <daniel@bowlhat.net>